### PR TITLE
Musicbrainz Album Search Overhaul

### DIFF
--- a/lib/shared/src/metadata.rs
+++ b/lib/shared/src/metadata.rs
@@ -43,6 +43,7 @@ pub struct SearchResults {
 pub enum SearchResult {
     Track(Track),
     Album(Album),
+    AlbumGroup(AlbumGroup),
 }
 
 /// A track from a metadata provider.
@@ -87,6 +88,29 @@ pub struct Album {
     /// URL to the album cover image.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cover_url: Option<String>,
+}
+
+/// This represents a general album entity, containing specific versions.
+/// Equivalent to a MusicBrainz release group.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct AlbumGroup {
+    /// Provider-specific identifier for lookups.
+    pub id: String,
+    /// The title of the album.
+    pub title: String,
+    /// A formatted string of the artist(s).
+    pub artist: String,
+    /// The release date of the album (YYYY-MM-DD).
+    pub release_date: Option<String>,
+    /// The MusicBrainz release ID, if known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mbid: Option<String>,
+    /// URL to the album cover image.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cover_url: Option<String>,
+    /// List of known editions of the album (e.g. deluxe, remastered, etc.).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub editions: Vec<Album>,
 }
 
 /// An album with its full track listing.

--- a/lib/shared/src/metadata.rs
+++ b/lib/shared/src/metadata.rs
@@ -119,3 +119,34 @@ pub struct AlbumWithTracks {
     pub album: Album,
     pub tracks: Vec<Track>,
 }
+
+/// Compare two MusicBrainz-style date strings, which can be in the format "YYYY", "YYYY-MM", or "YYYY-MM-DD".
+///
+/// The comparison logic is as follows: \
+/// First compare the year, then specificity, then full string for tie-breaking.
+/// This ensures that more specific dates (e.g. "1980-05") are sorted before less specific ones ("1980"),
+/// but when years are different, they are sorted chronologically regardless of specificity
+/// i.e. "1980-05" will come before "1980", but both will come after "1979-12".
+///
+/// This is a design choice, based on the intuition that a more specific date probably means more popular/definitive release.
+pub fn compare_musicbrainz_dates(
+    date1: &Option<impl AsRef<str>>,
+    date2: &Option<impl AsRef<str>>,
+) -> std::cmp::Ordering {
+    let date_a = date1.as_ref().map(|d| d.as_ref()).filter(|s| !s.is_empty());
+    let date_b = date2.as_ref().map(|d| d.as_ref()).filter(|s| !s.is_empty());
+
+    match (date_a, date_b) {
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (Some(a), Some(b)) => {
+            let year_a = &a[..a.len().min(4)];
+            let year_b = &b[..b.len().min(4)];
+
+            year_a.cmp(year_b) // 1. compare year
+                .then_with(|| b.len().cmp(&a.len())) // 2. more specific first
+                .then_with(|| a.cmp(b)) // 3. full chronological order
+        }
+    }
+}

--- a/lib/soulbeet/src/musicbrainz.rs
+++ b/lib/soulbeet/src/musicbrainz.rs
@@ -296,6 +296,19 @@ pub async fn search(
                     continue;
                 }
 
+                // For releases with more than 1 medium or with a single medium
+                // that is not "CD", "Digital Media" or "12\" Vinyl",
+                // it's likely a compilation, so skip it
+                if release.media.as_ref().is_some_and(|m| {
+                    m.len() > 1 ||
+                        m.len() == 1
+                            && m[0].format.as_deref() != Some("CD")
+                            && m[0].format.as_deref() != Some("Digital Media")
+                            && m[0].format.as_deref() != Some("12\" Vinyl")
+                }) {
+                    continue;
+                }
+
                 let rg_id = release.release_group.as_ref().unwrap().id.clone();
 
                 let title = match release.disambiguation.as_deref() {

--- a/lib/soulbeet/src/musicbrainz.rs
+++ b/lib/soulbeet/src/musicbrainz.rs
@@ -2,13 +2,15 @@ use musicbrainz_rs::{
     entity::{
         artist_credit::ArtistCredit,
         recording::{Recording, RecordingSearchQuery},
-        release::{Release, ReleaseStatus},
-        release_group::{ReleaseGroup, ReleaseGroupPrimaryType, ReleaseGroupSearchQuery},
+        release::{Release, ReleaseSearchQuery},
+        release_group::ReleaseGroupPrimaryType,
     },
     Fetch, MusicBrainzClient, Search,
 };
-use shared::metadata::{Album, AlbumWithTracks, SearchResult, Track};
+use shared::metadata::{Album, AlbumWithTracks, AlbumGroup, SearchResult, Track};
 use std::{collections::HashSet, future::Future, sync::OnceLock, time::Duration};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use tokio::time::sleep;
 use tracing::{info, warn};
 
@@ -97,10 +99,7 @@ fn is_retryable_error(error: &musicbrainz_rs::Error) -> bool {
 /// Retries an async operation with exponential backoff and request timeout.
 /// Only retries transient errors (network issues, timeouts, 5xx responses).
 /// Does NOT retry client errors (4xx) or permanent failures.
-async fn with_retry<T, F, Fut>(
-    operation_name: &str,
-    mut operation: F,
-) -> Result<T, musicbrainz_rs::Error>
+async fn with_retry<T, F, Fut>(operation_name: &str, mut operation: F) -> Result<T, musicbrainz_rs::Error>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<T, musicbrainz_rs::Error>>,
@@ -108,12 +107,11 @@ where
     let mut last_error = None;
 
     for attempt in 0..MAX_RETRIES {
-        // Respect MusicBrainz rate limit (1 req/sec)
-        crate::http::mb_rate_limit().await;
-
         // Apply timeout to each request
-        let result =
-            tokio::time::timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS), operation()).await;
+        let result = tokio::time::timeout(
+            Duration::from_secs(REQUEST_TIMEOUT_SECS),
+            operation()
+        ).await;
 
         match result {
             Ok(Ok(value)) => return Ok(value),
@@ -129,7 +127,10 @@ where
 
                 last_error = Some(e);
                 if attempt < MAX_RETRIES - 1 {
-                    let delay = std::cmp::min(BASE_DELAY_MS * 2u64.pow(attempt), MAX_BACKOFF_MS);
+                    let delay = std::cmp::min(
+                        BASE_DELAY_MS * 2u64.pow(attempt),
+                        MAX_BACKOFF_MS
+                    );
                     warn!(
                         "{} failed (attempt {}/{}), retrying in {}ms: {:?}",
                         operation_name,
@@ -150,18 +151,31 @@ where
                     attempt + 1,
                     MAX_RETRIES
                 );
-                last_error = Some(musicbrainz_rs::Error::MaxRetriesExceeded);
+                // Create a timeout error - we'll retry
                 if attempt < MAX_RETRIES - 1 {
-                    let delay = std::cmp::min(BASE_DELAY_MS * 2u64.pow(attempt), MAX_BACKOFF_MS);
+                    let delay = std::cmp::min(
+                        BASE_DELAY_MS * 2u64.pow(attempt),
+                        MAX_BACKOFF_MS
+                    );
                     sleep(Duration::from_millis(delay)).await;
                 }
             }
         }
     }
 
+    // Return the last error or panic (should never happen since we always set last_error on timeout)
+    // If we somehow have no error, create a synthetic one
     match last_error {
         Some(e) => Err(e),
-        None => Err(musicbrainz_rs::Error::MaxRetriesExceeded),
+        None => {
+            warn!(
+                "{} failed after {} retries with no recorded error (likely all timeouts)",
+                operation_name, MAX_RETRIES
+            );
+            // Re-run the operation one more time to get an error to return
+            // This is a fallback - shouldn't normally happen
+            operation().await
+        }
     }
 }
 
@@ -211,9 +225,7 @@ pub async fn search(
             recordings.sort_by(|a, b| {
                 let a_rating = a.rating.as_ref().and_then(|r| r.value).unwrap_or(0.0);
                 let b_rating = b.rating.as_ref().and_then(|r| r.value).unwrap_or(0.0);
-                b_rating
-                    .partial_cmp(&a_rating)
-                    .unwrap_or(std::cmp::Ordering::Equal)
+                b_rating.partial_cmp(&a_rating).unwrap_or(std::cmp::Ordering::Equal)
             });
 
             let mut unique_tracks = HashSet::new();
@@ -254,58 +266,112 @@ pub async fn search(
         }
         SearchType::Album => {
             let search_results = with_retry("MusicBrainz album search", || {
-                let mut album_query = ReleaseGroupSearchQuery::query_builder();
+                let mut album_query = ReleaseSearchQuery::query_builder();
                 if let Some(ref artist) = artist {
                     album_query.artist(artist).and();
                 }
-                let search_query = album_query.release_group(query).build();
+                let search_query = album_query.release(query).and().status("Official").build();
+                let limit = 100; // lower numbers (like 25) might not yield everything
                 async move {
-                    ReleaseGroup::search(search_query)
+                    Release::search(search_query)
                         .limit(limit)
-                        .with_releases()
-                        .with_ratings()
+                        .with_release_groups()
                         .execute_with_client(client)
                         .await
                 }
             })
             .await?;
 
-            // Sort by rating (descending) - higher rated albums first
-            let mut release_groups: Vec<_> = search_results.entities;
-            release_groups.sort_by(|a, b| {
-                let a_rating = a.rating.as_ref().and_then(|r| r.value).unwrap_or(0.0);
-                let b_rating = b.rating.as_ref().and_then(|r| r.value).unwrap_or(0.0);
-                b_rating
-                    .partial_cmp(&a_rating)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
+            // release_group_id -> unique releases
+            let mut unique_releases: HashMap<String, HashSet<String>> = HashMap::new();
+            let mut results_container: HashMap<String, AlbumGroup> = HashMap::new();
+            // track when release groups first appeared in response
+            // used to sort the final result vec
+            let mut rg_order: HashMap<String, usize> = HashMap::new();
 
-            for release_group in release_groups {
-                if release_group.primary_type != Some(ReleaseGroupPrimaryType::Album)
-                    && release_group.primary_type != Some(ReleaseGroupPrimaryType::Ep)
+            for release in search_results.entities {
+                if release.release_group.as_ref().unwrap().primary_type != Some(ReleaseGroupPrimaryType::Album)
+                    && release.release_group.as_ref().unwrap().primary_type != Some(ReleaseGroupPrimaryType::Ep)
                 {
                     continue;
                 }
 
-                if let Some(best_release) = release_group.releases.as_ref().and_then(|releases| {
-                    releases
-                        .iter()
-                        .filter(|r| r.status == Some(ReleaseStatus::Official))
-                        .min_by_key(|release| release.date.as_ref().map(|d| &d.0))
-                }) {
-                    // If no official release was found, take the first one available
-                    let final_release = best_release.clone();
+                let rg_id = release.release_group.as_ref().unwrap().id.clone();
 
-                    results.push(SearchResult::Album(Album {
-                        id: final_release.id.clone(),
-                        title: release_group.title.clone(),
-                        artist: format_artist_credit(&release_group.artist_credit),
-                        release_date: final_release.date.as_ref().map(|d| d.0.clone()),
-                        mbid: Some(final_release.id.clone()),
-                        cover_url: None,
-                    }));
+                let title = match release.disambiguation.as_deref() {
+                    None | Some("") => release.title.clone(),
+                    Some(disambiguation) => format!("{} ({})", release.title.clone(), disambiguation),
+                };
+
+                if !rg_order.contains_key(&rg_id) {
+                    rg_order.insert(rg_id.clone(), rg_order.len());
+                }
+                let release_group = unique_releases.entry(rg_id.clone()).or_default();
+                if !release_group.insert(title.clone()) {
+                    continue;
+                }
+
+                let edition = Album {
+                    id: release.id.clone(),
+                    title: title.clone(),
+                    artist: format_artist_credit(&release.artist_credit),
+                    release_date: release.date.as_ref().map(|d| d.0.clone()),
+                    mbid: Some(release.id.clone()),
+                    cover_url: Some(format!("https://coverartarchive.org/release/{}/front-250", release.id)),
+                };
+                match results_container.entry(rg_id.clone()) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(AlbumGroup {
+                            id: rg_id.clone(),
+                            title: release.release_group.unwrap().title.clone(),
+                            artist: format_artist_credit(&release.artist_credit),
+                            release_date: edition.release_date.clone(),
+                            mbid: Some(rg_id.clone()),
+                            cover_url: Some(format!(
+                                "https://coverartarchive.org/release-group/{}/front-250",
+                                rg_id
+                            )),
+                            editions: vec![edition],
+                        });
+                    }
+                    Entry::Occupied(mut entry) => {
+                        let existing = entry.get_mut();
+
+                        let existing_date = existing.release_date.as_deref().filter(|s| !s.is_empty());
+                        let new_date = edition.release_date.as_deref().filter(|s| !s.is_empty());
+
+                        match (existing_date, new_date) {
+                            (None, Some(date)) => {
+                                existing.release_date = Some(date.to_string());
+                            }
+                            (Some(ex_date), Some(n_date)) if n_date < ex_date => {
+                                existing.release_date = Some(n_date.to_string());
+                            }
+                            _ => {}
+                        }
+
+                        existing.editions.push(edition);
+                    }
                 }
             }
+
+            results.extend(results_container.into_values().map(SearchResult::AlbumGroup));
+
+            results.sort_by(|a, b| {
+                let SearchResult::AlbumGroup(a_album) = a else { return std::cmp::Ordering::Equal; };
+                let SearchResult::AlbumGroup(b_album) = b else { return std::cmp::Ordering::Equal; };
+                let a_rg_rank = rg_order.get(&a_album.id).unwrap_or(&usize::MAX);
+                let b_rg_rank = rg_order.get(&b_album.id).unwrap_or(&usize::MAX);
+                let is_missing = |date: &Option<String>| {
+                    date.as_deref().unwrap_or("").is_empty()
+                };
+                // First sort by release group rank (i.e. when they appeared in the musicbrainz response)
+                a_rg_rank.cmp(&b_rg_rank)
+                    // Then push releases without release date to the back
+                    .then(is_missing(&a_album.release_date).cmp(&is_missing(&b_album.release_date)))
+                    // Then sort by release date
+                    .then(a_album.release_date.cmp(&b_album.release_date))
+            });
         }
     }
 
@@ -398,7 +464,7 @@ impl crate::MetadataProvider for MusicBrainzProvider {
         limit: usize,
     ) -> crate::error::Result<Vec<SearchResult>> {
         let artist_opt = artist.map(String::from);
-        search(&artist_opt, query, SearchType::Album, limit.min(100) as u8)
+        search(&artist_opt, query, SearchType::Album, limit as u8)
             .await
             .map_err(|e| crate::error::SoulseekError::Api {
                 status: 500,
@@ -413,7 +479,7 @@ impl crate::MetadataProvider for MusicBrainzProvider {
         limit: usize,
     ) -> crate::error::Result<Vec<SearchResult>> {
         let artist_opt = artist.map(String::from);
-        search(&artist_opt, query, SearchType::Track, limit.min(100) as u8)
+        search(&artist_opt, query, SearchType::Track, limit as u8)
             .await
             .map_err(|e| crate::error::SoulseekError::Api {
                 status: 500,
@@ -422,11 +488,9 @@ impl crate::MetadataProvider for MusicBrainzProvider {
     }
 
     async fn get_album(&self, id: &str) -> crate::error::Result<AlbumWithTracks> {
-        find_album(id)
-            .await
-            .map_err(|e| crate::error::SoulseekError::Api {
-                status: 500,
-                message: e.to_string(),
-            })
+        find_album(id).await.map_err(|e| crate::error::SoulseekError::Api {
+            status: 500,
+            message: e.to_string(),
+        })
     }
 }

--- a/lib/soulbeet/src/musicbrainz.rs
+++ b/lib/soulbeet/src/musicbrainz.rs
@@ -377,7 +377,7 @@ pub async fn search(
                 let b_rg_rank = rg_order.get(&b_album.id).unwrap_or(&usize::MAX);
 
                 // First sort by release group rank (i.e. when they appeared in the musicbrainz response)
-                a_rg_rank.cmp(&b_rg_rank)
+                a_rg_rank.cmp(b_rg_rank)
                     // then compare by date
                     .then(compare_musicbrainz_dates(&a_album.release_date, &b_album.release_date))
             });
@@ -427,10 +427,15 @@ pub async fn find_album(release_id: &str) -> Result<AlbumWithTracks, musicbrainz
         }
     }
 
+    let title = match release.disambiguation.as_deref() {
+        None | Some("") => release.title.clone(),
+        Some(disambiguation) => format!("{} ({})", release.title.clone(), disambiguation),
+    };
+
     // First, create the standalone Album object.
     let album = Album {
         id: release.id.clone(),
-        title: release.title,
+        title,
         artist: format_artist_credit(&release.artist_credit),
         release_date: release.date.map(|d| d.0),
         mbid: Some(release.id),

--- a/lib/soulbeet/src/musicbrainz.rs
+++ b/lib/soulbeet/src/musicbrainz.rs
@@ -7,7 +7,7 @@ use musicbrainz_rs::{
     },
     Fetch, MusicBrainzClient, Search,
 };
-use shared::metadata::{Album, AlbumWithTracks, AlbumGroup, SearchResult, Track};
+use shared::metadata::{Album, AlbumWithTracks, AlbumGroup, SearchResult, Track, compare_musicbrainz_dates};
 use std::{collections::HashSet, future::Future, sync::OnceLock, time::Duration};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -282,9 +282,10 @@ pub async fn search(
             })
             .await?;
 
-            // release_group_id -> unique releases
-            let mut unique_releases: HashMap<String, HashSet<String>> = HashMap::new();
-            let mut results_container: HashMap<String, AlbumGroup> = HashMap::new();
+            // release_group_id -> (Title -> Album (edition))
+            let mut results_container: HashMap<String, HashMap<String, Album>> = HashMap::new();
+            // release_group_id -> release group title
+            let mut release_groups: HashMap<String, String> = HashMap::new();
             // track when release groups first appeared in response
             // used to sort the final result vec
             let mut rg_order: HashMap<String, usize> = HashMap::new();
@@ -319,10 +320,7 @@ pub async fn search(
                 if !rg_order.contains_key(&rg_id) {
                     rg_order.insert(rg_id.clone(), rg_order.len());
                 }
-                let release_group = unique_releases.entry(rg_id.clone()).or_default();
-                if !release_group.insert(title.clone()) {
-                    continue;
-                }
+
 
                 let edition = Album {
                     id: release.id.clone(),
@@ -332,58 +330,56 @@ pub async fn search(
                     mbid: Some(release.id.clone()),
                     cover_url: Some(format!("https://coverartarchive.org/release/{}/front-250", release.id)),
                 };
-                match results_container.entry(rg_id.clone()) {
+
+                // Use the release group ID to track unique releases and avoid duplicates based on title.
+                // However, for releases with the same title and release group ID,
+                // we keep the oldest one (based on release date) to ensure we get the canonical release
+                let release_group = results_container.entry(rg_id.clone()).or_insert_with(|| {
+                    release_groups.insert(rg_id.clone(), release.release_group.as_ref().unwrap().title.clone());
+                    HashMap::new()
+                });
+
+                match release_group.entry(title.clone()) {
                     Entry::Vacant(entry) => {
-                        entry.insert(AlbumGroup {
-                            id: rg_id.clone(),
-                            title: release.release_group.unwrap().title.clone(),
-                            artist: format_artist_credit(&release.artist_credit),
-                            release_date: edition.release_date.clone(),
-                            mbid: Some(rg_id.clone()),
-                            cover_url: Some(format!(
-                                "https://coverartarchive.org/release-group/{}/front-250",
-                                rg_id
-                            )),
-                            editions: vec![edition],
-                        });
+                        entry.insert(edition);
                     }
                     Entry::Occupied(mut entry) => {
-                        let existing = entry.get_mut();
-
-                        let existing_date = existing.release_date.as_deref().filter(|s| !s.is_empty());
-                        let new_date = edition.release_date.as_deref().filter(|s| !s.is_empty());
-
-                        match (existing_date, new_date) {
-                            (None, Some(date)) => {
-                                existing.release_date = Some(date.to_string());
-                            }
-                            (Some(ex_date), Some(n_date)) if n_date < ex_date => {
-                                existing.release_date = Some(n_date.to_string());
-                            }
-                            _ => {}
+                        let existing = entry.get();
+                        let new_date: Option<&str> = release.date.as_ref().map(|d| d.0.as_ref());
+                        if compare_musicbrainz_dates(&existing.release_date, &new_date) == std::cmp::Ordering::Greater {
+                            entry.insert(edition);
                         }
-
-                        existing.editions.push(edition);
                     }
                 }
             }
 
-            results.extend(results_container.into_values().map(SearchResult::AlbumGroup));
+            // Flatten the results container into a single vector of SearchResult::AlbumGroup
+            for (rg_id, editions) in results_container.into_iter() {
+                let oldest_edition = editions.values().min_by(|a, b|
+                    compare_musicbrainz_dates(&a.release_date, &b.release_date)
+                ).unwrap();
+                let album_group = AlbumGroup {
+                    id: rg_id.clone(),
+                    title: release_groups.get(&rg_id).unwrap_or(&oldest_edition.title).clone(),
+                    artist: oldest_edition.artist.clone(),
+                    release_date: oldest_edition.release_date.clone(),
+                    mbid: Some(rg_id.clone()),
+                    cover_url: Some(format!("https://coverartarchive.org/release-group/{}/front-250", rg_id)),
+                    editions: editions.into_values().collect(),
+                };
+                results.push(SearchResult::AlbumGroup(album_group));
+            }
 
             results.sort_by(|a, b| {
                 let SearchResult::AlbumGroup(a_album) = a else { return std::cmp::Ordering::Equal; };
                 let SearchResult::AlbumGroup(b_album) = b else { return std::cmp::Ordering::Equal; };
                 let a_rg_rank = rg_order.get(&a_album.id).unwrap_or(&usize::MAX);
                 let b_rg_rank = rg_order.get(&b_album.id).unwrap_or(&usize::MAX);
-                let is_missing = |date: &Option<String>| {
-                    date.as_deref().unwrap_or("").is_empty()
-                };
+
                 // First sort by release group rank (i.e. when they appeared in the musicbrainz response)
                 a_rg_rank.cmp(&b_rg_rank)
-                    // Then push releases without release date to the back
-                    .then(is_missing(&a_album.release_date).cmp(&is_missing(&b_album.release_date)))
-                    // Then sort by release date
-                    .then(a_album.release_date.cmp(&b_album.release_date))
+                    // then compare by date
+                    .then(compare_musicbrainz_dates(&a_album.release_date, &b_album.release_date))
             });
         }
     }

--- a/ui/src/components/search/album.rs
+++ b/ui/src/components/search/album.rs
@@ -41,7 +41,7 @@ pub fn AlbumResult(props: Props) -> Element {
             "{album.title}"
           }
           p { class: "text-xs text-gray-400 font-mono truncate", "{album.artist}" }
-          if let Some(release_date) = &album.release_date {
+          if let Some(release_date) = album.release_date.as_ref().filter(|s| !s.is_empty()) {
             p { class: "text-xs text-gray-500 font-mono", "{release_date}" }
           }
         }

--- a/ui/src/components/search/albumgroup.rs
+++ b/ui/src/components/search/albumgroup.rs
@@ -1,5 +1,5 @@
 use dioxus::prelude::*;
-use shared::metadata::{Album, AlbumGroup};
+use shared::metadata::{Album, AlbumGroup, compare_musicbrainz_dates};
 
 use crate::CoverArt;
 use super::album::AlbumResult;
@@ -39,11 +39,7 @@ pub fn AlbumGroupResult(props: Props) -> Element {
     }
     
     // Sort editions by date
-    editions.sort_by(|a, b| {
-        let date_a = a.release_date.as_deref().filter(|s| !s.is_empty()).unwrap_or("9999-12-31");
-        let date_b = b.release_date.as_deref().filter(|s| !s.is_empty()).unwrap_or("9999-12-31");
-        date_a.cmp(date_b)
-    });
+    editions.sort_by(|a, b| compare_musicbrainz_dates(&a.release_date, &b.release_date));
 
     // SAFETY: We know there's at least 2 editions here, so unwrap is fine
     let oldest_edition = editions.first().unwrap();

--- a/ui/src/components/search/albumgroup.rs
+++ b/ui/src/components/search/albumgroup.rs
@@ -1,13 +1,24 @@
+use api::models::folder::Folder;
 use dioxus::prelude::*;
 use shared::metadata::{Album, AlbumGroup, compare_musicbrainz_dates};
 
+use super::download_icon::{DownloadIcon, DownloadRowState};
 use crate::CoverArt;
-use super::album::AlbumResult;
+use crate::search::edition::EditionResult;
 
 #[derive(Props, PartialEq, Clone)]
 pub struct Props {
     pub album_group: AlbumGroup,
     pub on_edition_click: Callback<String>,
+    pub on_search_sources: Callback,
+    pub download_state: DownloadRowState,
+    pub folders: Vec<Folder>,
+    pub selected_folder_id: Option<String>,
+    pub active_menu: Signal<Option<String>>,
+    #[props(into)]
+    pub on_download: EventHandler<()>,
+    #[props(into)]
+    pub on_override_download: EventHandler<Folder>,
 }
 
 #[component]
@@ -26,12 +37,12 @@ pub fn AlbumGroupResult(props: Props) -> Element {
         cover_url: props.album_group.cover_url.clone(),
     };
 
-    // If there's only one edition (or none), just render it as a normal AlbumResult
+    // If there's only one edition (or none), just render it as a normal EditionResult
     if editions.len() <= 1 {
         let album = editions.pop().unwrap_or_else(|| cover_album);
         let album_id = album.id.clone();
         return rsx! {
-            AlbumResult {
+            EditionResult {
                 album,
                 on_click: move |_| props.on_edition_click.call(album_id.clone())
             }
@@ -51,29 +62,68 @@ pub fn AlbumGroupResult(props: Props) -> Element {
         
         // Main Header, looks basically like AlbumResult
         div {
-            onclick: move |_| {
-                props.on_edition_click.call(oldest_id.clone());
-            },
-            class: "p-4 flex items-center gap-4 cursor-pointer group transition-colors",
+            class: "p-4 flex items-center gap-4 group transition-colors",
 
-            CoverArt { album: cover_album }
+            div {
+              class: "flex-grow flex items-center gap-4 cursor-pointer",
+              onclick: move |_| {
+                  props.on_edition_click.call(oldest_id.clone());
+              },
+              CoverArt { album: cover_album }
 
-            div { class: "flex-grow flex flex-col justify-center",
-                div { class: "flex items-center gap-2",
-                  h5 { class: "text-lg font-bold text-white group-hover:text-beet-accent transition-colors",
-                      "{props.album_group.title}"
+              div { class: "flex-grow flex flex-col justify-center",
+                  div { class: "flex items-center gap-2",
+                    h5 { class: "text-lg font-bold text-white group-hover:text-beet-accent transition-colors",
+                        "{props.album_group.title}"
+                    }
                   }
-                }
-                p { class: "text-md text-gray-400 font-mono", "{props.album_group.artist}" }
-                if let Some(release_date) = props.album_group.release_date.as_ref().filter(|s| !s.is_empty()) {
-                    p { class: "text-sm text-gray-500 mt-1 font-mono", "{release_date}" }
-                }
+                  p { class: "text-md text-gray-400 font-mono", "{props.album_group.artist}" }
+                  if let Some(release_date) = props.album_group.release_date.as_ref().filter(|s| !s.is_empty()) {
+                      p { class: "text-sm text-gray-500 mt-1 font-mono", "{release_date}" }
+                  }
+              }
             }
             
-            // Show edition count if not expanded
-            if !expanded() && !editions.is_empty() {
-                div { class: "text-xs font-mono text-gray-500 bg-white/5 px-2 py-1 rounded",
-                    "{editions.len()} editions"
+            // Action buttons
+            div { class: "flex items-center gap-1 shrink-0",
+                // Show edition count if not expanded
+                if !expanded() && !editions.is_empty() {
+                    div { class: "text-xs font-mono text-gray-500 bg-white/5 px-2 py-1 rounded mr-2",
+                        "{editions.len()} editions"
+                    }
+                }
+
+                // Search sources button
+                button {
+                    class: "p-2 rounded-full hover:bg-white/10 transition-colors cursor-pointer group/src",
+                    title: "Search sources",
+                    onclick: move |evt: MouseEvent| {
+                        evt.stop_propagation();
+                        props.on_search_sources.call(());
+                    },
+                    svg {
+                        class: "w-4 h-4 text-gray-500 group-hover/src:text-white transition-colors",
+                        fill: "none",
+                        stroke: "currentColor",
+                        stroke_width: "2",
+                        view_box: "0 0 24 24",
+                        path {
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            d: "M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z",
+                        }
+                    }
+                }
+
+                // Auto-download button
+                DownloadIcon {
+                    item_id: props.album_group.id.clone(),
+                    state: props.download_state.clone(),
+                    folders: props.folders.clone(),
+                    selected_folder_id: props.selected_folder_id.clone(),
+                    active_menu: props.active_menu,
+                    on_download: props.on_download,
+                    on_override_download: props.on_override_download,
                 }
             }
         }
@@ -118,7 +168,7 @@ pub fn AlbumGroupResult(props: Props) -> Element {
                   span { "Available Editions" }
                 }
                 for edition in editions {
-                    AlbumResult {
+                    EditionResult {
                         key: "{edition.id.clone()}",
                         album: edition.clone(),
                         on_click: move |_| props.on_edition_click.call(edition.id.clone()),

--- a/ui/src/components/search/albumgroup.rs
+++ b/ui/src/components/search/albumgroup.rs
@@ -45,16 +45,15 @@ pub fn AlbumGroupResult(props: Props) -> Element {
         date_a.cmp(date_b)
     });
 
-    let oldest_edition = editions.first();
-    let oldest_id = oldest_edition
-        .map(|e| e.id.clone())
-        .unwrap_or_else(|| props.album_group.id.clone());
+    // SAFETY: We know there's at least 2 editions here, so unwrap is fine
+    let oldest_edition = editions.first().unwrap();
+    let oldest_id = oldest_edition.id.clone();
     
     rsx! {
       div {
         class: "flex flex-col bg-white/5 border border-white/5 rounded-lg overflow-hidden transition-all duration-200 hover:border-beet-accent/30",
         
-        // Main Header
+        // Main Header, looks basically like AlbumResult
         div {
             onclick: move |_| {
                 props.on_edition_click.call(oldest_id.clone());
@@ -83,7 +82,7 @@ pub fn AlbumGroupResult(props: Props) -> Element {
             }
         }
 
-        // The "Flat Arrow" bar at the bottom of the element
+        // Bar with arrow at bottom of the list card item to toggle editions
         if !editions.is_empty() {
             div {
                 onclick: move |evt| {

--- a/ui/src/components/search/albumgroup.rs
+++ b/ui/src/components/search/albumgroup.rs
@@ -1,0 +1,136 @@
+use dioxus::prelude::*;
+use shared::metadata::{Album, AlbumGroup};
+
+use crate::CoverArt;
+use super::album::AlbumResult;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct Props {
+    pub album_group: AlbumGroup,
+    pub on_edition_click: Callback<String>,
+}
+
+#[component]
+pub fn AlbumGroupResult(props: Props) -> Element {
+    let mut expanded = use_signal(|| false);
+    let mut editions = props.album_group.editions.clone();
+
+
+    // Construct a dummy Album for CoverArt
+    let cover_album = Album {
+        id: props.album_group.id.clone(),
+        title: props.album_group.title.clone(),
+        artist: props.album_group.artist.clone(),
+        release_date: props.album_group.release_date.clone(),
+        mbid: props.album_group.mbid.clone(),
+        cover_url: props.album_group.cover_url.clone(),
+    };
+
+    // If there's only one edition (or none), just render it as a normal AlbumResult
+    if editions.len() <= 1 {
+        let album = editions.pop().unwrap_or_else(|| cover_album);
+        let album_id = album.id.clone();
+        return rsx! {
+            AlbumResult {
+                album,
+                on_click: move |_| props.on_edition_click.call(album_id.clone())
+            }
+        };
+    }
+    
+    // Sort editions by date
+    editions.sort_by(|a, b| {
+        let date_a = a.release_date.as_deref().filter(|s| !s.is_empty()).unwrap_or("9999-12-31");
+        let date_b = b.release_date.as_deref().filter(|s| !s.is_empty()).unwrap_or("9999-12-31");
+        date_a.cmp(date_b)
+    });
+
+    let oldest_edition = editions.first();
+    let oldest_id = oldest_edition
+        .map(|e| e.id.clone())
+        .unwrap_or_else(|| props.album_group.id.clone());
+    
+    rsx! {
+      div {
+        class: "flex flex-col bg-white/5 border border-white/5 rounded-lg overflow-hidden transition-all duration-200 hover:border-beet-accent/30",
+        
+        // Main Header
+        div {
+            onclick: move |_| {
+                props.on_edition_click.call(oldest_id.clone());
+            },
+            class: "p-4 flex items-center gap-4 cursor-pointer group transition-colors",
+
+            CoverArt { album: cover_album }
+
+            div { class: "flex-grow flex flex-col justify-center",
+                div { class: "flex items-center gap-2",
+                  h5 { class: "text-lg font-bold text-white group-hover:text-beet-accent transition-colors",
+                      "{props.album_group.title}"
+                  }
+                }
+                p { class: "text-md text-gray-400 font-mono", "{props.album_group.artist}" }
+                if let Some(release_date) = props.album_group.release_date.as_ref().filter(|s| !s.is_empty()) {
+                    p { class: "text-sm text-gray-500 mt-1 font-mono", "{release_date}" }
+                }
+            }
+            
+            // Show edition count if not expanded
+            if !expanded() && !editions.is_empty() {
+                div { class: "text-xs font-mono text-gray-500 bg-white/5 px-2 py-1 rounded",
+                    "{editions.len()} editions"
+                }
+            }
+        }
+
+        // The "Flat Arrow" bar at the bottom of the element
+        if !editions.is_empty() {
+            div {
+                onclick: move |evt| {
+                    evt.stop_propagation();
+                    expanded.toggle();
+                },
+                class: "h-8 flex justify-center items-center hover:bg-beet-accent/10 cursor-pointer border-t border-white/5 transition-all duration-300 group",
+                svg {
+                    class: "w-6 h-6 text-gray-500 group-hover:text-beet-accent transform transition-transform duration-300",
+                    fill: "none",
+                    stroke: "currentColor",
+                    view_box: "0 0 24 24",
+                    if expanded() {
+                        path {
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            stroke_width: "2",
+                            d: "M22 14l-10-6-10 6",
+                        }
+                    } else {
+                        path {
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            stroke_width: "2",
+                            d: "M22 10l-10 6-10-6",
+                        }
+                    }
+                }
+            }
+        }
+
+        // Expanded editions
+        if expanded() {
+            div {
+                class: "p-4 pt-2 space-y-3",
+                div { class: "text-[10px] text-gray-500 font-mono uppercase tracking-widest mb-2 flex items-center gap-2",
+                  span { "Available Editions" }
+                }
+                for edition in editions {
+                    AlbumResult {
+                        key: "{edition.id.clone()}",
+                        album: edition.clone(),
+                        on_click: move |_| props.on_edition_click.call(edition.id.clone()),
+                    }
+                }
+            }
+        }
+      }
+    }
+}

--- a/ui/src/components/search/edition.rs
+++ b/ui/src/components/search/edition.rs
@@ -1,0 +1,34 @@
+use dioxus::prelude::*;
+use shared::metadata::Album;
+
+use crate::CoverArt;
+
+#[derive(Props, PartialEq, Clone)]
+pub struct Props {
+    pub album: Album,
+    pub on_click: Callback,
+}
+
+#[component]
+pub fn EditionResult(props: Props) -> Element {
+    let album = &props.album;
+
+    rsx! {
+      div {
+        onclick: move |_| props.on_click.call(()),
+        class: "bg-white/5 border border-white/5 p-4 rounded-lg hover:border-beet-accent/50 hover:bg-white/10 transition-all duration-200 flex items-center gap-4 cursor-pointer group",
+
+        CoverArt { album: album.clone() }
+
+        div { class: "flex-grow flex flex-col justify-center",
+          h5 { class: "text-lg font-bold text-white group-hover:text-beet-accent transition-colors",
+            "{album.title}"
+          }
+          p { class: "text-md text-gray-400 font-mono", "{album.artist}" }
+          if let Some(release_date) = album.release_date.as_ref().filter(|s| !s.is_empty()) {
+            p { class: "text-sm text-gray-500 mt-1 font-mono", "{release_date}" }
+          }
+        }
+      }
+    }
+}

--- a/ui/src/components/search/mod.rs
+++ b/ui/src/components/search/mod.rs
@@ -1,5 +1,6 @@
 pub mod album;
 mod albumgroup;
+mod edition;
 pub mod context;
 pub mod track;
 
@@ -744,13 +745,63 @@ pub fn Search() -> Element {
                                 }
                             }
                             SearchResult::AlbumGroup(ref album_group) => {
+                                let album_group_clone = album_group.clone();
+                                let album_group_for_dl = album_group.clone();
+                                let album_group_for_override = album_group.clone();
+                                let album_group_id = album_group.id.clone();
+                                let dl_state = download_states.read().get(&album_group_id).cloned().unwrap_or_default();
+                                let has_folders = !folders.read().is_empty();
+                                let effective_state = if !has_folders { DownloadRowState::Disabled } else { dl_state };
+                                let current_folders = folders.read().clone();
+                                let current_folder_id = selected_folder_id();
+
                                 rsx! {
                                   li { key: "{album_group.id}",
                                     AlbumGroupResult {
                                       album_group: album_group.clone(),
-                                        on_edition_click: move |edition_id: String| {
-                                          spawn(view_full_album(edition_id, provider));
-                                        },
+                                      on_edition_click: move |edition_id: String| {
+                                        spawn(view_full_album(edition_id, provider));
+                                      },
+                                      on_search_sources: {
+                                          let album_for_search = album_group.clone();
+                                          move || {
+                                              let query = DownloadQuery::new(vec![]).album(shared::metadata::Album {
+                                                  id: album_for_search.id.clone(),
+                                                  title: album_for_search.title.clone(),
+                                                  artist: album_for_search.artist.clone(),
+                                                  release_date: album_for_search.release_date.clone(),
+                                                  mbid: album_for_search.mbid.clone(),
+                                                  cover_url: album_for_search.cover_url.clone(),
+                                              });
+                                              spawn(download(query));
+                                          }
+                                      },
+                                      download_state: effective_state,
+                                      folders: current_folders,
+                                      selected_folder_id: current_folder_id.clone(),
+                                      active_menu,
+                                      on_download: move |_| {
+                                          let query = DownloadQuery::new(vec![]).album(shared::metadata::Album {
+                                              id: album_group_for_dl.id.clone(),
+                                              title: album_group_for_dl.title.clone(),
+                                              artist: album_group_for_dl.artist.clone(),
+                                              release_date: album_group_for_dl.release_date.clone(),
+                                              mbid: album_group_for_dl.mbid.clone(),
+                                              cover_url: album_group_for_dl.cover_url.clone(),
+                                          });
+                                          handle_auto_download(album_group_for_dl.id.clone(), query);
+                                      },
+                                      on_override_download: move |folder: Folder| {
+                                          let query = DownloadQuery::new(vec![]).album(shared::metadata::Album {
+                                              id: album_group_for_override.id.clone(),
+                                              title: album_group_for_override.title.clone(),
+                                              artist: album_group_for_override.artist.clone(),
+                                              release_date: album_group_for_override.release_date.clone(),
+                                              mbid: album_group_for_override.mbid.clone(),
+                                              cover_url: album_group_for_override.cover_url.clone(),
+                                          });
+                                          handle_override_download(album_group_for_override.id.clone(), query, folder);
+                                      },
                                     }
                                   }
                                 }

--- a/ui/src/components/search/mod.rs
+++ b/ui/src/components/search/mod.rs
@@ -1,4 +1,5 @@
 pub mod album;
+mod albumgroup;
 pub mod context;
 pub mod track;
 
@@ -26,6 +27,7 @@ use std::collections::HashMap;
 use track::TrackResult;
 
 use crate::search::album::AlbumResult;
+use crate::search::albumgroup::AlbumGroupResult;
 use crate::settings_context::use_settings;
 use crate::{use_auth, Album, AlbumHeader, Button, Modal, SystemStatus};
 
@@ -741,6 +743,19 @@ pub fn Search() -> Element {
                                   }
                                 }
                             }
+                            SearchResult::AlbumGroup(ref album_group) => {
+                                rsx! {
+                                  li { key: "{album_group.id}",
+                                    AlbumGroupResult {
+                                      album_group: album_group.clone(),
+                                        on_edition_click: move |edition_id: String| {
+                                          spawn(view_full_album(edition_id, provider));
+                                        },
+                                    }
+                                  }
+                                }
+                            }
+
                         }
                       }
                     }


### PR DESCRIPTION
This PR aims to solve #29 and various other issues with search.

When searching for an album, we do a release query and group the releases by release group, filter them by unique name (including the `disambiguation` field) and sorting by date.
We choose the oldest release as canonical version of the album/release group. This release will be picked when just clicking the list item in the search results (as before). A dropdown can be expanded to select specific editions.

**TODO**
- [x] Make sure the default pick is the correct one (could be a special edition before).
- [x] Show different editions in a dropdown.
- [x] Display the correct name when selecting a release/edition.
- [x] Make sure the correct string is searched in slskd.
- [x] Test compatibility with last.fm search.