### PR TITLE
Add "Require FLAC only" setting for search and auto-download

### DIFF
--- a/api/migrations/20260716000000_require_flac_only.sql
+++ b/api/migrations/20260716000000_require_flac_only.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_settings ADD COLUMN require_flac_only BOOLEAN NOT NULL DEFAULT 0;

--- a/api/src/models/user_settings.rs
+++ b/api/src/models/user_settings.rs
@@ -9,6 +9,7 @@ pub struct UserSettings {
     pub default_metadata_provider: Option<String>,
     pub last_search_type: Option<String>,
     pub auto_delete_enabled: bool,
+    pub require_flac_only: bool,
     pub lastfm_api_key: Option<String>,
     pub lastfm_username: Option<String>,
     pub discovery_promote_threshold: u8,
@@ -34,6 +35,8 @@ pub struct UpdateUserSettings {
     pub last_search_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_delete_enabled: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub require_flac_only: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lastfm_api_key: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -78,6 +81,7 @@ impl UserSettings {
             default_metadata_provider: Some("musicbrainz".to_string()),
             last_search_type: Some("album".to_string()),
             auto_delete_enabled: false,
+            require_flac_only: false,
             lastfm_api_key: None,
             lastfm_username: None,
             discovery_promote_threshold: 3,
@@ -107,6 +111,9 @@ impl UserSettings {
         let auto_delete = update
             .auto_delete_enabled
             .unwrap_or(current.auto_delete_enabled);
+        let require_flac_only = update
+            .require_flac_only
+            .unwrap_or(current.require_flac_only);
         let lastfm_key = update.lastfm_api_key.or(current.lastfm_api_key);
         let lastfm_user = update.lastfm_username.or(current.lastfm_username);
         let promote_threshold = update
@@ -141,12 +148,13 @@ impl UserSettings {
 
         sqlx::query(
             r#"
-            INSERT INTO user_settings (user_id, default_metadata_provider, last_search_type, auto_delete_enabled, lastfm_api_key, lastfm_username, discovery_promote_threshold, navidrome_banner_dismissed, listenbrainz_username, listenbrainz_token, discovery_enabled, discovery_folder_id, discovery_track_count, discovery_lifetime_days, discovery_profiles, discovery_playlist_name, default_download_folder_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO user_settings (user_id, default_metadata_provider, last_search_type, auto_delete_enabled, require_flac_only, lastfm_api_key, lastfm_username, discovery_promote_threshold, navidrome_banner_dismissed, listenbrainz_username, listenbrainz_token, discovery_enabled, discovery_folder_id, discovery_track_count, discovery_lifetime_days, discovery_profiles, discovery_playlist_name, default_download_folder_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(user_id) DO UPDATE SET
                 default_metadata_provider = excluded.default_metadata_provider,
                 last_search_type = excluded.last_search_type,
                 auto_delete_enabled = excluded.auto_delete_enabled,
+                require_flac_only = excluded.require_flac_only,
                 lastfm_api_key = excluded.lastfm_api_key,
                 lastfm_username = excluded.lastfm_username,
                 discovery_promote_threshold = excluded.discovery_promote_threshold,
@@ -166,6 +174,7 @@ impl UserSettings {
         .bind(&provider)
         .bind(&search_type)
         .bind(auto_delete)
+        .bind(require_flac_only)
         .bind(&lastfm_key)
         .bind(&lastfm_user)
         .bind(promote_threshold)

--- a/api/src/server_fns/discovery.rs
+++ b/api/src/server_fns/discovery.rs
@@ -489,7 +489,10 @@ pub async fn generate_discovery_playlist_internal(
                     release_mbid: None,
                 }];
 
-                let search_id = match backend.start_search(None, &search_tracks).await {
+                let search_id = match backend
+                    .start_search(None, &search_tracks, settings.require_flac_only)
+                    .await
+                {
                     Ok(id) => id,
                     Err(e) => {
                         warn!(

--- a/api/src/server_fns/download/auto_download.rs
+++ b/api/src/server_fns/download/auto_download.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 #[cfg(feature = "server")]
 use crate::globals::{get_or_create_user_channel, register_user_task, unregister_user_task};
 #[cfg(feature = "server")]
+use crate::models::user_settings::UserSettings;
+#[cfg(feature = "server")]
 use crate::services::{available_download_backends, download_backend};
 #[cfg(feature = "server")]
 use crate::AuthSession;
@@ -57,6 +59,10 @@ pub enum AutoDownloadResult {
 #[post("/api/auto-download", auth: AuthSession)]
 pub async fn auto_download(req: AutoDownloadRequest) -> Result<AutoDownloadResult, ServerFnError> {
     let username = auth.0.username;
+    let require_flac = UserSettings::get(&auth.0.sub)
+        .await
+        .map(|s| s.require_flac_only)
+        .unwrap_or(false);
     let (tx, _) = get_or_create_user_channel(&username).await;
 
     let mut req = req;
@@ -146,7 +152,10 @@ pub async fn auto_download(req: AutoDownloadRequest) -> Result<AutoDownloadResul
                 let tracks = tracks.clone();
                 async move {
                     // Start search
-                    let search_id = match backend.start_search(album.as_ref(), &tracks).await {
+                    let search_id = match backend
+                        .start_search(album.as_ref(), &tracks, require_flac)
+                        .await
+                    {
                         Ok(sid) => sid,
                         Err(e) => {
                             warn!("Backend {} search start failed: {}", id, e);

--- a/api/src/server_fns/search.rs
+++ b/api/src/server_fns/search.rs
@@ -115,17 +115,23 @@ pub(crate) async fn hydrate_album_tracks(query: &mut DownloadQuery) -> Result<()
     Ok(())
 }
 
-#[post("/api/download/search/start", _: AuthSession)]
+#[post("/api/download/search/start", auth: AuthSession)]
 pub async fn start_download_search(data: DownloadQuery) -> Result<String, ServerFnError> {
     let mut data = data;
     hydrate_album_tracks(&mut data).await.map_err(server_error)?;
+
+    let user_settings = UserSettings::get(&auth.0.sub).await.map_err(server_error)?;
 
     let backend = download_backend(data.backend.as_deref())
         .await
         .map_err(|e| server_error(format!("download backend not available: {}", e)))?;
 
     backend
-        .start_search(data.album.as_ref(), &data.tracks)
+        .start_search(
+            data.album.as_ref(),
+            &data.tracks,
+            user_settings.require_flac_only,
+        )
         .await
         .map_err(server_error)
 }

--- a/lib/soulbeet/src/slskd/client.rs
+++ b/lib/soulbeet/src/slskd/client.rs
@@ -53,6 +53,7 @@ struct SearchContext {
     start_time: DateTime<Utc>,
     timeout: Duration,
     seen_response_count: usize,
+    require_flac: bool,
 }
 
 #[derive(Debug)]
@@ -288,6 +289,7 @@ impl SoulseekClient {
         album: Option<Album>,
         tracks: Vec<Track>,
         timeout: Duration,
+        require_flac: bool,
     ) -> Result<String> {
         self.wait_for_rate_limit().await?;
 
@@ -344,6 +346,7 @@ impl SoulseekClient {
                 start_time: Utc::now(),
                 timeout,
                 seen_response_count: 0,
+                require_flac,
             },
         );
 
@@ -401,6 +404,7 @@ impl SoulseekClient {
                             &context.artist,
                             context.album.as_deref(),
                             &track_titles_ref,
+                            context.require_flac,
                         );
 
                         albums.sort_by(|a, b| {
@@ -433,6 +437,7 @@ impl SoulseekClient {
                                 &context.artist,
                                 context.album.as_deref(),
                                 &track_titles_ref,
+                                context.require_flac,
                             );
                             albums.sort_by(|a, b| {
                                 b.score
@@ -1067,9 +1072,14 @@ impl crate::DownloadBackend for SoulseekClient {
         "Soulseek"
     }
 
-    async fn start_search(&self, album: Option<&Album>, tracks: &[Track]) -> Result<String> {
+    async fn start_search(
+        &self,
+        album: Option<&Album>,
+        tracks: &[Track],
+        require_flac: bool,
+    ) -> Result<String> {
         let timeout = Duration::seconds(120);
-        self.start_search(album.cloned(), tracks.to_vec(), timeout)
+        self.start_search(album.cloned(), tracks.to_vec(), timeout, require_flac)
             .await
     }
 

--- a/lib/soulbeet/src/slskd/processing.rs
+++ b/lib/soulbeet/src/slskd/processing.rs
@@ -10,6 +10,7 @@ pub fn process_search_responses(
     searched_artist: &str,
     searched_album: Option<&str>,
     expected_tracks: &[&str],
+    require_flac: bool,
 ) -> Vec<AlbumResult> {
     const MIN_SCORE_THRESHOLD: f64 = 0.6;
     let audio_extensions: HashSet<&str> = ["flac", "wav", "m4a", "ogg", "aac", "wma", "mp3"]
@@ -27,7 +28,14 @@ pub fn process_search_responses(
                     .and_then(|s| s.to_str())
                     .map(|s| s.to_lowercase());
 
-                if let Some(ext) = ext {
+                if require_flac {
+                    // Strict mode: only confirmed FLAC files pass. Unlike the
+                    // default allowlist below, an unlabeled extension is not
+                    // trusted to be FLAC and is excluded.
+                    if ext.as_deref() != Some("flac") {
+                        return None;
+                    }
+                } else if let Some(ext) = &ext {
                     if !audio_extensions.contains(ext.as_str()) {
                         return None;
                     }
@@ -161,4 +169,121 @@ fn find_best_albums(
             })
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::slskd::models::SearchResponseFile;
+
+    fn file(filename: &str) -> SearchResponseFile {
+        SearchResponseFile {
+            filename: filename.to_string(),
+            size: 30_000_000,
+            bit_rate: None,
+            length: None,
+            sample_rate: None,
+            bit_depth: None,
+        }
+    }
+
+    fn response(username: &str, files: Vec<SearchResponseFile>) -> SearchResponse {
+        SearchResponse {
+            username: username.to_string(),
+            files,
+            has_free_upload_slot: true,
+            upload_speed: 500,
+            queue_length: 0,
+        }
+    }
+
+    /// `require_flac: false` must behave exactly as before this feature was
+    /// added: both a FLAC source and an MP3 source are valid candidates, so
+    /// both users' groups come back.
+    #[test]
+    fn require_flac_false_keeps_all_supported_formats() {
+        let responses = vec![
+            response(
+                "flac_user",
+                vec![file("Test Artist/Test Album/01 Song One.flac")],
+            ),
+            response(
+                "mp3_user",
+                vec![file("Test Artist/Test Album/01 Song One.mp3")],
+            ),
+        ];
+
+        let results = process_search_responses(
+            &responses,
+            "Test Artist",
+            Some("Test Album"),
+            &["Song One"],
+            false,
+        );
+
+        assert_eq!(results.len(), 2, "both flac and mp3 sources should match");
+        let qualities: HashSet<_> = results.iter().map(|r| r.dominant_quality.as_str()).collect();
+        assert!(qualities.contains("flac"));
+        assert!(qualities.contains("mp3"));
+    }
+
+    /// `require_flac: true` must hard-exclude non-FLAC files before matching,
+    /// not just down-rank them: a lossy-only source should never appear in
+    /// the results at all.
+    #[test]
+    fn require_flac_true_excludes_non_flac_sources() {
+        let responses = vec![
+            response(
+                "flac_user",
+                vec![file("Test Artist/Test Album/01 Song One.flac")],
+            ),
+            response(
+                "mp3_user",
+                vec![file("Test Artist/Test Album/01 Song One.mp3")],
+            ),
+        ];
+
+        let results = process_search_responses(
+            &responses,
+            "Test Artist",
+            Some("Test Album"),
+            &["Song One"],
+            true,
+        );
+
+        assert_eq!(results.len(), 1, "the mp3-only source must be excluded entirely");
+        assert_eq!(results[0].username, "flac_user");
+        assert_eq!(results[0].dominant_quality, "flac");
+    }
+
+    /// `require_flac: true` on a peer who only has some tracks in FLAC must
+    /// keep just the FLAC tracks (lower completeness) rather than filling the
+    /// gap with a lossy file from the same folder.
+    #[test]
+    fn require_flac_true_drops_only_the_non_flac_tracks_in_a_mixed_group() {
+        let responses = vec![response(
+            "mixed_user",
+            vec![
+                file("Test Artist/Test Album/01 Song One.flac"),
+                file("Test Artist/Test Album/02 Song Two.mp3"),
+            ],
+        )];
+
+        let results = process_search_responses(
+            &responses,
+            "Test Artist",
+            Some("Test Album"),
+            &["Song One", "Song Two"],
+            true,
+        );
+
+        assert_eq!(results.len(), 1);
+        let group = &results[0];
+        assert_eq!(group.track_count, 1, "only the flac track should survive");
+        assert_eq!(group.dominant_quality, "flac");
+        assert!(group
+            .tracks
+            .iter()
+            .all(|t| t.base.filename.ends_with(".flac")));
+    }
 }

--- a/lib/soulbeet/src/traits.rs
+++ b/lib/soulbeet/src/traits.rs
@@ -39,7 +39,12 @@ pub trait DownloadBackend: Send + Sync {
     fn id(&self) -> &'static str;
     fn name(&self) -> &'static str;
 
-    async fn start_search(&self, album: Option<&Album>, tracks: &[Track]) -> Result<String>;
+    async fn start_search(
+        &self,
+        album: Option<&Album>,
+        tracks: &[Track],
+        require_flac: bool,
+    ) -> Result<String>;
     async fn poll_search(&self, search_id: &str) -> Result<SearchResult>;
     async fn download(&self, items: Vec<DownloadableItem>) -> Result<Vec<QueuedDownload>>;
     async fn get_downloads(&self) -> Result<Vec<DownloadProgress>>;

--- a/ui/src/components/settings/preferences.rs
+++ b/ui/src/components/settings/preferences.rs
@@ -7,6 +7,7 @@ use crate::settings_context::use_settings;
 pub fn PreferencesManager() -> Element {
     let mut settings = use_settings();
     let mut selected_provider = use_signal(|| settings.default_provider());
+    let mut require_flac_only = use_signal(|| settings.require_flac_only());
     let mut error = use_signal(String::new);
     let mut success_msg = use_signal(String::new);
     let mut saving = use_signal(|| false);
@@ -15,6 +16,7 @@ pub fn PreferencesManager() -> Element {
     use_effect(move || {
         if settings.is_loaded() && !synced() {
             selected_provider.set(settings.default_provider());
+            require_flac_only.set(settings.require_flac_only());
             synced.set(true);
         }
     });
@@ -105,6 +107,36 @@ pub fn PreferencesManager() -> Element {
                     } else {
                         p { class: "text-xs text-gray-500 mt-1 font-mono",
                             "Choose which service to use for searching albums and tracks."
+                        }
+                    }
+                }
+
+                div { class: "flex items-center justify-between p-3 bg-beet-dark rounded border border-white/10",
+                    div {
+                        p { class: "text-sm text-white font-medium", "Require FLAC only" }
+                        p { class: "text-xs text-gray-500 font-mono mt-0.5",
+                            "Only accept FLAC sources for search and auto-download. Non-FLAC results are excluded entirely, not just down-ranked."
+                        }
+                    }
+                    button {
+                        class: format!(
+                            "relative w-11 h-6 rounded-full cursor-pointer transition-colors {}",
+                            if require_flac_only() { "bg-beet-accent" } else { "bg-gray-600" }
+                        ),
+                        onclick: move |_| async move {
+                            let new_val = !require_flac_only();
+                            require_flac_only.set(new_val);
+                            let update = api::UpdateUserSettings {
+                                require_flac_only: Some(new_val),
+                                ..Default::default()
+                            };
+                            let _ = settings.update(update).await;
+                        },
+                        span {
+                            class: format!(
+                                "absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform {}",
+                                if require_flac_only() { "translate-x-5" } else { "" }
+                            ),
                         }
                     }
                 }

--- a/ui/src/settings_context.rs
+++ b/ui/src/settings_context.rs
@@ -87,6 +87,15 @@ impl Settings {
         self.providers.read().clone()
     }
 
+    /// Whether search/download results are restricted to FLAC only.
+    pub fn require_flac_only(&self) -> bool {
+        self.state
+            .read()
+            .as_ref()
+            .map(|s| s.require_flac_only)
+            .unwrap_or(false)
+    }
+
     /// Update settings (call after successful API update).
     pub fn set(&mut self, settings: UserSettings) {
         self.state.set(Some(settings));


### PR DESCRIPTION
## Summary

Today's quality scoring is soft-only: `SearchResult::quality_score()` weights FLAC highest (1.0 vs. mp3=0.55, m4a/aac=0.65, etc.), but that's just one input into `album_quality_score`, so a high-confidence MP3/M4A match can still outscore and win over a lower-confidence FLAC one. There's currently no way to hard-require FLAC.

This adds a per-user "Require FLAC only" toggle (Settings → Search) that hard-excludes non-FLAC files *before* matching/scoring — so when it's on, a result group can only ever be built from confirmed-FLAC files. If a peer only has some tracks of an album in FLAC, you get a smaller/incomplete group rather than one padded out with lossy tracks for the missing songs.

### Changes
- New `require_flac_only` column on `user_settings` (migration + model, following the existing `auto_delete_enabled`-style boolean pattern)
- Settings UI toggle in `PreferencesManager`, styled like the existing auto-delete switch in `folder_manager.rs`
- Threaded through `DownloadBackend::start_search` → `SearchContext` → `process_search_responses`, so it applies uniformly to manual search, auto-download, and Discovery-sourced downloads
- First unit tests in the repo (`lib/soulbeet/src/slskd/processing.rs`): a regression guard for the existing `require_flac_only=false` behavior, plus coverage for the hard-exclude and mixed-format-group cases

## Possible extension (not included here, flagging for discussion)

Right now the per-format weights (`flac=1.0, wav=0.85, m4a=0.65, mp3=0.55, ogg=0.6, wma=0.4`) and thresholds (`MIN_SCORE_THRESHOLD`, `AUTO_SELECT_SCORE_THRESHOLD`) are hardcoded constants. A more general version of this feature could expose those as user-configurable settings — e.g. a minimum-acceptable-quality tier instead of a FLAC-or-nothing boolean, or letting users re-weight `avg_score`/`completeness`/`avg_format_score` in `album_quality_score`. That would cover cases like "320kbps MP3 is fine, but nothing below that" or "I care more about completeness than format purity." Kept out of this PR to keep the diff small and reviewable — happy to follow up if that's a direction you'd want.

## Disclosure

This PR was written with [Claude Code](https://claude.com/claude-code) — I described the problem and reviewed the resulting diff, but wanted to flag the authorship explicitly. If you'd rather implement this yourself (or a different approach entirely) than review an AI-authored change, no hard feelings — feel free to close this and I'm happy to just describe the use case instead.

## Test plan

Verified locally with rustc/cargo 1.97.0 (stable) plus the `wasm32-unknown-unknown` target:

- [x] New unit tests in `processing.rs` pass — `cargo test -p soulbeet` → 3/3 ok (require_flac=false regression guard, hard-exclude of non-flac sources, mixed-format group handling)
- [x] Server build compiles clean — `cargo build --package web --features server` (api + soulbeet + ui + web) with the fullstack route macros resolving `dioxus_server` correctly
- [x] Client build compiles clean — `cargo check --package web --features web --target wasm32-unknown-unknown` (verifies the settings toggle UI)
- [x] No new clippy warnings or rustfmt diffs on the changed lines (the repo's pre-existing warnings/formatting are untouched)
- [ ] Manual end-to-end check on a live deployment: toggle "Require FLAC only" on, search for a track known to have both FLAC and MP3 sources, confirm only FLAC results/downloads come back

> Note: a plain `cargo build -p api --features server` fails with `unresolved crate dioxus_server` errors — but that's a pre-existing Dioxus-fullstack quirk unrelated to this change (untouched `master` produces the identical errors). The route macros only resolve `dioxus_server` when built through the top-level `web` package that enables `dioxus/server`, which is how the Dockerfile/CI builds it. Building through `web` (as above) compiles everything cleanly.
