### PR TITLE
Stop cancelling downloads that are still active in slskd

### DIFF
--- a/api/src/server_fns/download/monitor.rs
+++ b/api/src/server_fns/download/monitor.rs
@@ -545,17 +545,29 @@ impl DownloadMonitor {
     }
 
     /// Check if all downloads are complete. Returns true if monitoring should stop.
+    ///
+    /// A track is settled when it was processed (imported, failed, or timed
+    /// out) or its transfer reached a terminal state. Settled must be judged
+    /// per track: in album mode completed tracks stay unprocessed until the
+    /// whole batch is handled, so requiring all-processed or all-terminal
+    /// across the batch would poll forever once one track is processed via
+    /// timeout while the rest sit completed.
     async fn check_completion(&mut self, batch_status: &[DownloadProgress]) -> bool {
-        let all_processed = self.track_states.values().all(|s| s.processed);
-        let all_terminal = self.filenames.iter().all(|fname| {
-            batch_status
+        let all_settled = self.filenames.iter().all(|fname| {
+            let processed = self
+                .track_states
+                .get(fname)
+                .map(|s| s.processed)
+                .unwrap_or(true);
+            let terminal = batch_status
                 .iter()
                 .find(|d| filenames_match(&d.item, fname))
                 .map(|d| is_terminal_state(&d.state))
-                .unwrap_or(false)
+                .unwrap_or(false);
+            processed || terminal
         });
 
-        if all_processed || all_terminal {
+        if all_settled {
             if self.album_mode {
                 self.process_album_mode(batch_status).await;
             }

--- a/e2e/stubs/src/slskd-state.ts
+++ b/e2e/stubs/src/slskd-state.ts
@@ -77,20 +77,27 @@ interface TransferRecord {
   delivered: boolean;
 }
 
+// Transfers hold "Requested" and "Initializing" for longer than the app's 2s
+// monitor poll interval so every download is guaranteed to be observed in
+// those states: treating them as terminal made the monitor cancel live
+// transfers (issue #71).
 const BEHAVIOR_PLANS: Record<Exclude<PeerBehavior, 'offline'>, TransferStep[]> = {
   happy: [
     { afterMs: 0, state: 'Queued, Locally', percent: 0 },
-    { afterMs: 400, state: 'Queued, Remotely', percent: 0 },
-    { afterMs: 900, state: 'InProgress', percent: 24 },
-    { afterMs: 1600, state: 'InProgress', percent: 71 },
-    { afterMs: 2300, state: 'Completed, Succeeded', percent: 100, deliverFile: true },
+    { afterMs: 100, state: 'Requested', percent: 0 },
+    { afterMs: 2600, state: 'Queued, Remotely', percent: 0 },
+    { afterMs: 3400, state: 'Initializing', percent: 0 },
+    { afterMs: 5900, state: 'InProgress', percent: 24 },
+    { afterMs: 6600, state: 'InProgress', percent: 71 },
+    { afterMs: 7300, state: 'Completed, Succeeded', percent: 100, deliverFile: true },
   ],
   flaky: [
     { afterMs: 0, state: 'Queued, Locally', percent: 0 },
-    { afterMs: 400, state: 'Queued, Remotely', percent: 0 },
-    { afterMs: 900, state: 'InProgress', percent: 31 },
+    { afterMs: 100, state: 'Requested', percent: 0 },
+    { afterMs: 2600, state: 'Queued, Remotely', percent: 0 },
+    { afterMs: 3100, state: 'InProgress', percent: 31 },
     {
-      afterMs: 1800,
+      afterMs: 4000,
       state: 'Completed, Errored',
       percent: 31,
       exception: 'Connection reset by peer',
@@ -291,9 +298,9 @@ export class SlskdState {
         failed.push(file.filename);
         continue;
       }
-      // Real slskd enqueues straight into "Queued, Locally"
-      // (DownloadService.EnqueueAsync); a transfer is never visible in any
-      // earlier state.
+      // Real slskd creates the record in "Queued, Locally"
+      // (DownloadService.EnqueueAsync), then the download task overwrites the
+      // state with Soulseek.NET's own progression starting at "Requested".
       const transfer: TransferRecord = {
         id: randomUUID(),
         username,

--- a/lib/shared/src/slskd.rs
+++ b/lib/shared/src/slskd.rs
@@ -26,12 +26,15 @@ pub struct DownloadResponse {
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum DownloadState {
     InProgress,
+    Initializing,
     Importing,
     Queued,
+    Requested,
     Downloaded,
     Imported,
     ImportSkipped,
     Errored,
+    TimedOut,
     ImportFailed,
     Aborted,
     Cancelled,
@@ -43,10 +46,16 @@ impl From<String> for DownloadState {
     fn from(s: String) -> Self {
         match s.as_str() {
             "Queued" => DownloadState::Queued,
+            "Requested" => DownloadState::Requested,
+            // Initial/unset state, before the request is sent to the peer
+            "None" => DownloadState::Requested,
+            "Initializing" => DownloadState::Initializing,
             "InProgress" => DownloadState::InProgress,
             "Completed" => DownloadState::Downloaded,
+            "Succeeded" => DownloadState::Downloaded,
             "Aborted" => DownloadState::Aborted,
             "Cancelled" => DownloadState::Cancelled,
+            "TimedOut" => DownloadState::TimedOut,
             "Rejected" => DownloadState::Rejected,
             "Errored" => DownloadState::Errored,
             "Importing" => DownloadState::Importing,
@@ -185,10 +194,15 @@ impl FileEntry {
 ///
 /// TransferStates is a flags enum: Completed=16, Succeeded=32,
 /// Cancelled=64, TimedOut=128, Errored=256, Rejected=512,
-/// Aborted=1024. Queued=2, InProgress=8. Locally=2048, Remotely=4096.
+/// Aborted=1024. None=0, Requested=1, Queued=2, Initializing=4,
+/// InProgress=8. Locally=2048, Remotely=4096.
 ///
 /// Check terminal reasons first (Completed + reason flag), then active states.
 fn bitfield_to_download_state(value: u64) -> DownloadState {
+    const REQUESTED: u64 = 1;
+    const QUEUED: u64 = 2;
+    const INITIALIZING: u64 = 4;
+    const IN_PROGRESS: u64 = 8;
     const COMPLETED: u64 = 16;
     const SUCCEEDED: u64 = 32;
     const CANCELLED: u64 = 64;
@@ -196,8 +210,6 @@ fn bitfield_to_download_state(value: u64) -> DownloadState {
     const ERRORED: u64 = 256;
     const REJECTED: u64 = 512;
     const ABORTED: u64 = 1024;
-    const QUEUED: u64 = 2;
-    const IN_PROGRESS: u64 = 8;
 
     if value & COMPLETED != 0 {
         if value & SUCCEEDED != 0 {
@@ -210,7 +222,7 @@ fn bitfield_to_download_state(value: u64) -> DownloadState {
             return DownloadState::Cancelled;
         }
         if value & TIMED_OUT != 0 {
-            return DownloadState::Errored;
+            return DownloadState::TimedOut;
         }
         if value & ERRORED != 0 {
             return DownloadState::Errored;
@@ -224,8 +236,16 @@ fn bitfield_to_download_state(value: u64) -> DownloadState {
     if value & IN_PROGRESS != 0 {
         return DownloadState::InProgress;
     }
+    if value & INITIALIZING != 0 {
+        return DownloadState::Initializing;
+    }
     if value & QUEUED != 0 {
         return DownloadState::Queued;
+    }
+    if value & REQUESTED != 0 || value == 0 {
+        // Requested, or None (0): the transfer exists but hasn't reached a
+        // queue yet. Both precede Queued in the slskd lifecycle.
+        return DownloadState::Requested;
     }
 
     DownloadState::Unknown(format!("bitfield:{}", value))
@@ -556,6 +576,7 @@ impl From<FileEntry> for crate::download::DownloadProgress {
                     | DownloadState::Errored
                     | DownloadState::Aborted
                     | DownloadState::Cancelled
+                    | DownloadState::TimedOut
                     | DownloadState::ImportFailed
             )
         }) {
@@ -589,6 +610,8 @@ impl From<DownloadState> for crate::download::DownloadState {
         use crate::download::DownloadState as DS;
         match state {
             DownloadState::Queued => DS::Queued,
+            DownloadState::Requested => DS::Queued,
+            DownloadState::Initializing => DS::InProgress,
             DownloadState::InProgress => DS::InProgress,
             DownloadState::Downloaded => DS::Completed,
             DownloadState::Importing => DS::Importing,
@@ -599,7 +622,12 @@ impl From<DownloadState> for crate::download::DownloadState {
             DownloadState::Aborted => DS::Failed("Aborted".into()),
             DownloadState::Cancelled => DS::Cancelled,
             DownloadState::Rejected => DS::Failed("Transfer rejected by peer".into()),
-            DownloadState::Unknown(s) => DS::Failed(format!("Unknown state: {s}")),
+            DownloadState::TimedOut => DS::Failed("Download timed out".into()),
+            // Unrecognized states must never map to a terminal state: the
+            // monitor treats terminal as finished and cancels the live slskd
+            // transfer (issue #71). Treat as active; the per-track timeout
+            // is the backstop if the state never advances.
+            DownloadState::Unknown(_) => DS::Queued,
         }
     }
 }
@@ -630,5 +658,103 @@ impl crate::download::DownloadableItem {
             album: self.album.clone(),
             match_score: self.quality_score,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::download::DownloadState as DS;
+    use serde_json::json;
+
+    /// Deserialize a transfer entry exactly as slskd's API would return it,
+    /// with the given `state` value (string or numeric bitfield), and return
+    /// the DownloadState the monitor would see.
+    fn mapped(state: serde_json::Value) -> DS {
+        let entry: FileEntry = serde_json::from_value(json!({
+            "id": "890f943c-02e1-4d45-af76-d55e3d855684",
+            "username": "peer",
+            "direction": "Download",
+            "filename": "shared\\Artist\\Album\\01. Track.flac",
+            "size": 1024,
+            "state": state,
+            "stateDescription": "",
+            "requestedAt": "2026-07-19T05:11:22Z",
+            "bytesTransferred": 0,
+            "bytesRemaining": 1024,
+            "percentComplete": 0.0
+        }))
+        .expect("FileEntry should deserialize");
+        crate::download::DownloadProgress::from(entry).state
+    }
+
+    #[test]
+    fn active_transfer_states_stay_active() {
+        // Every state a live slskd transfer passes through before completion.
+        // Mapping any of these to a terminal state makes the monitor declare
+        // the batch finished and cancel the transfer (issue #71).
+        for state in [
+            "None",
+            "Requested",
+            "Queued, Locally",
+            "Queued, Remotely",
+            "Initializing",
+            "InProgress",
+        ] {
+            let got = mapped(json!(state));
+            assert!(
+                matches!(got, DS::Queued | DS::InProgress),
+                "string state {state:?} mapped to {got:?}"
+            );
+        }
+        // Same states as numeric bitfields: None, Requested,
+        // Queued|Locally, Queued|Remotely, Initializing, InProgress.
+        for value in [0u64, 1, 2050, 4098, 4, 8] {
+            let got = mapped(json!(value));
+            assert!(
+                matches!(got, DS::Queued | DS::InProgress),
+                "bitfield state {value} mapped to {got:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn completed_states_map_to_their_outcome() {
+        assert_eq!(mapped(json!("Completed, Succeeded")), DS::Completed);
+        assert_eq!(mapped(json!("Completed, Cancelled")), DS::Cancelled);
+        for state in [
+            "Completed, Errored",
+            "Completed, Rejected",
+            "Completed, Aborted",
+            "Completed, TimedOut",
+        ] {
+            let got = mapped(json!(state));
+            assert!(
+                matches!(got, DS::Failed(_)),
+                "string state {state:?} mapped to {got:?}"
+            );
+        }
+        // Completed|Succeeded, Completed|Cancelled as bitfields
+        assert_eq!(mapped(json!(48u64)), DS::Completed);
+        assert_eq!(mapped(json!(80u64)), DS::Cancelled);
+        // Completed|Errored, Completed|Rejected, Completed|Aborted, Completed|TimedOut
+        for value in [272u64, 528, 1040, 144] {
+            let got = mapped(json!(value));
+            assert!(
+                matches!(got, DS::Failed(_)),
+                "bitfield state {value} mapped to {got:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unrecognized_states_never_map_terminal() {
+        for state in [json!("SomethingNew"), json!("Weird, Flags"), json!(8192u64)] {
+            let got = mapped(state.clone());
+            assert!(
+                matches!(got, DS::Queued | DS::InProgress),
+                "unrecognized state {state} mapped to {got:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
slskd reports transfers in Requested and Initializing before bytes start moving. We had no mapping for those states so they came through as Failed, the monitor considered the batch finished and the cleanup then cancelled transfers that were still running. That is the "task was canceled" error from #71.

While in there:

- Completed, TimedOut was read as a successful download and handed to beets. Now it fails the track like the other completion reasons.
- Unrecognized states no longer count as terminal, so a future slskd version can't trigger this again. The per-track timeout covers genuinely stuck transfers.
- Album batches complete per track instead of waiting for every transfer to land in the same bucket, which could poll forever when one track failed by timeout.

The e2e stub now walks through the real state sequence with long enough dwell that the monitor has to observe Requested and Initializing, and the mapping has unit tests for every state slskd can emit, string and numeric. Checked the transfer API against slskd master (0.26.0): same states, same serialization.

Closes #71